### PR TITLE
fix: #75 fix windows github action build by manually converting into anyhow::Error

### DIFF
--- a/src/resource.rs
+++ b/src/resource.rs
@@ -225,7 +225,8 @@ impl FlaggableRegEx {
     pub fn from_persistable(pfre: &PersistableFlaggableRegEx) -> anyhow::Result<Self> {
         Ok(FlaggableRegEx {
             regex: regex::Regex::new(&pfre.regex)?,
-            flags: bitflags::parser::from_str(&pfre.flags)?,
+            flags: bitflags::parser::from_str(&pfre.flags)
+               .map_err(|e| anyhow::Error::msg(format!("{}", e)))?,
             nature_regex_capture: pfre.nature_regex_capture.clone(),
         })
     }


### PR DESCRIPTION
Fixes the GitHub action build error for the Windows platform. Fixed by manually converting to anyhow::Error.