### PR TITLE
fix: #77 rename macos build artifact as per naming convention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
           - { target: x86_64-apple-darwin, cross: false }
     steps:
       - uses: actions/checkout@v2
+      - name: Extract Release Version
+        id: release_version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -46,13 +49,13 @@ jobs:
         run: |
           cargo build --release --target ${{ matrix.triple.target }}
           ./target/${{ matrix.triple.target }}/release/surveilr --help
-          zip -r ${{ matrix.triple.target }}-release.zip target/${{ matrix.triple.target }}/release/surveilr
+          zip -r resource-surveillance_${{github.ref_name}}_${{ matrix.triple.target }}.zip target/${{ matrix.triple.target }}/release/surveilr
       - name: Upload to Release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }} # This is the upload URL for the release
-          asset_path: ${{ matrix.triple.target }}-release.zip
-          asset_name: ${{ matrix.triple.target }}-release.zip
+          asset_path: resource-surveillance_${{github.ref_name}}_${{ matrix.triple.target }}.zip
+          asset_name: resource-surveillance_${{github.ref_name}}_${{ matrix.triple.target }}.zip
           asset_content_type: application/zip


### PR DESCRIPTION
Fixes the naming convention issue for the macOS GitHub Action build artifact.