### PR TITLE
feat: add deno script to convert xml-to-json as test fixtures #45

### DIFF
--- a/support/test-fixtures/xml-to-json-mtm-types.ts
+++ b/support/test-fixtures/xml-to-json-mtm-types.ts
@@ -1,0 +1,428 @@
+// To parse this data:
+//
+//   import { Convert, XML } from "./file";
+//
+//   const xML = Convert.toXML(json);
+//
+// These functions will throw an error if the JSON doesn't
+// match the expected interface, even if the JSON is valid.
+
+export interface XML {
+    ThreatModel: ThreatModel;
+}
+
+export interface ThreatModel {
+    DrawingSurfaceList:      DrawingSurfaceList;
+    MetaInformation:         MetaInformation;
+    Notes:                   string;
+    ThreatGenerationEnabled: boolean;
+    Validations:             string;
+    Version:                 number;
+    Profile:                 Profile;
+}
+
+export interface DrawingSurfaceList {
+    DrawingSurfaceModel: DrawingSurfaceModel;
+}
+
+export interface DrawingSurfaceModel {
+    GenericTypeId: string;
+    Guid:          string;
+    Properties:    DrawingSurfaceModelProperties;
+    TypeId:        string;
+    Borders:       Borders;
+    Header:        string;
+    Lines:         Lines;
+    Zoom:          number;
+}
+
+export interface Borders {
+    KeyValueOfguidanyType: BordersKeyValueOfguidanyType[];
+}
+
+export interface BordersKeyValueOfguidanyType {
+    Key:   string;
+    Value: PurpleValue;
+}
+
+export interface PurpleValue {
+    GenericTypeId:   string;
+    Guid:            string;
+    Properties:      PurpleProperties;
+    TypeId:          string;
+    Height:          number;
+    Left:            number;
+    StrokeDashArray: string;
+    StrokeThickness: number;
+    Top:             number;
+    Width:           number;
+}
+
+export interface PurpleProperties {
+    anyType: PurpleAnyType[];
+}
+
+export interface PurpleAnyType {
+    DisplayName:    string;
+    Name:           string;
+    Value:          boolean | FluffyValue | number | string;
+    SelectedIndex?: number;
+}
+
+export interface FluffyValue {
+    string: string[];
+}
+
+export interface Lines {
+    KeyValueOfguidanyType: LinesKeyValueOfguidanyType[];
+}
+
+export interface LinesKeyValueOfguidanyType {
+    Key:   string;
+    Value: TentacledValue;
+}
+
+export interface TentacledValue {
+    GenericTypeId: string;
+    Guid:          string;
+    Properties:    FluffyProperties;
+    TypeId:        string;
+    HandleX:       number;
+    HandleY:       number;
+    PortSource:    string;
+    PortTarget:    string;
+    SourceGuid:    string;
+    SourceX:       number;
+    SourceY:       number;
+    TargetGuid:    string;
+    TargetX:       number;
+    TargetY:       number;
+}
+
+export interface FluffyProperties {
+    anyType: FluffyAnyType[];
+}
+
+export interface FluffyAnyType {
+    DisplayName:    string;
+    Name:           string;
+    Value:          boolean | StickyValue | ValueEnum | number;
+    SelectedIndex?: number;
+}
+
+export interface StickyValue {
+    string: string[] | string;
+}
+
+export enum ValueEnum {
+    Empty = "",
+    GenericDataFlow = "Generic Data\n                  Flow",
+    HTTPS = "HTTPS",
+}
+
+export interface DrawingSurfaceModelProperties {
+    anyType: TentacledAnyType[];
+}
+
+export interface TentacledAnyType {
+    DisplayName: string;
+    Name:        string;
+    Value:       string;
+}
+
+export interface MetaInformation {
+    Assumptions:                string;
+    Contributors:               string;
+    ExternalDependencies:       string;
+    HighLevelSystemDescription: string;
+    Owner:                      string;
+    Reviewer:                   string;
+    ThreatModelName:            string;
+}
+
+export interface Profile {
+    PromptedKb: string;
+}
+
+// Converts JSON strings to/from your types
+// and asserts the results of JSON.parse at runtime
+export class Convert {
+    public static toXML(json: string): XML {
+        return cast(JSON.parse(json), r("XML"));
+    }
+
+    public static xMLToJson(value: XML): string {
+        return JSON.stringify(uncast(value, r("XML")), null, 2);
+    }
+}
+
+function invalidValue(typ: any, val: any, key: any, parent: any = ''): never {
+    const prettyTyp = prettyTypeName(typ);
+    const parentText = parent ? ` on ${parent}` : '';
+    const keyText = key ? ` for key "${key}"` : '';
+    throw Error(`Invalid value${keyText}${parentText}. Expected ${prettyTyp} but got ${JSON.stringify(val)}`);
+}
+
+function prettyTypeName(typ: any): string {
+    if (Array.isArray(typ)) {
+        if (typ.length === 2 && typ[0] === undefined) {
+            return `an optional ${prettyTypeName(typ[1])}`;
+        } else {
+            return `one of [${typ.map(a => { return prettyTypeName(a); }).join(", ")}]`;
+        }
+    } else if (typeof typ === "object" && typ.literal !== undefined) {
+        return typ.literal;
+    } else {
+        return typeof typ;
+    }
+}
+
+function jsonToJSProps(typ: any): any {
+    if (typ.jsonToJS === undefined) {
+        const map: any = {};
+        typ.props.forEach((p: any) => map[p.json] = { key: p.js, typ: p.typ });
+        typ.jsonToJS = map;
+    }
+    return typ.jsonToJS;
+}
+
+function jsToJSONProps(typ: any): any {
+    if (typ.jsToJSON === undefined) {
+        const map: any = {};
+        typ.props.forEach((p: any) => map[p.js] = { key: p.json, typ: p.typ });
+        typ.jsToJSON = map;
+    }
+    return typ.jsToJSON;
+}
+
+function transform(val: any, typ: any, getProps: any, key: any = '', parent: any = ''): any {
+    function transformPrimitive(typ: string, val: any): any {
+        if (typeof typ === typeof val) return val;
+        return invalidValue(typ, val, key, parent);
+    }
+
+    function transformUnion(typs: any[], val: any): any {
+        // val must validate against one typ in typs
+        const l = typs.length;
+        for (let i = 0; i < l; i++) {
+            const typ = typs[i];
+            try {
+                return transform(val, typ, getProps);
+            } catch (_) {}
+        }
+        return invalidValue(typs, val, key, parent);
+    }
+
+    function transformEnum(cases: string[], val: any): any {
+        if (cases.indexOf(val) !== -1) return val;
+        return invalidValue(cases.map(a => { return l(a); }), val, key, parent);
+    }
+
+    function transformArray(typ: any, val: any): any {
+        // val must be an array with no invalid elements
+        if (!Array.isArray(val)) return invalidValue(l("array"), val, key, parent);
+        return val.map(el => transform(el, typ, getProps));
+    }
+
+    function transformDate(val: any): any {
+        if (val === null) {
+            return null;
+        }
+        const d = new Date(val);
+        if (isNaN(d.valueOf())) {
+            return invalidValue(l("Date"), val, key, parent);
+        }
+        return d;
+    }
+
+    function transformObject(props: { [k: string]: any }, additional: any, val: any): any {
+        if (val === null || typeof val !== "object" || Array.isArray(val)) {
+            return invalidValue(l(ref || "object"), val, key, parent);
+        }
+        const result: any = {};
+        Object.getOwnPropertyNames(props).forEach(key => {
+            const prop = props[key];
+            const v = Object.prototype.hasOwnProperty.call(val, key) ? val[key] : undefined;
+            result[prop.key] = transform(v, prop.typ, getProps, key, ref);
+        });
+        Object.getOwnPropertyNames(val).forEach(key => {
+            if (!Object.prototype.hasOwnProperty.call(props, key)) {
+                result[key] = transform(val[key], additional, getProps, key, ref);
+            }
+        });
+        return result;
+    }
+
+    if (typ === "any") return val;
+    if (typ === null) {
+        if (val === null) return val;
+        return invalidValue(typ, val, key, parent);
+    }
+    if (typ === false) return invalidValue(typ, val, key, parent);
+    let ref: any = undefined;
+    while (typeof typ === "object" && typ.ref !== undefined) {
+        ref = typ.ref;
+        typ = typeMap[typ.ref];
+    }
+    if (Array.isArray(typ)) return transformEnum(typ, val);
+    if (typeof typ === "object") {
+        return typ.hasOwnProperty("unionMembers") ? transformUnion(typ.unionMembers, val)
+            : typ.hasOwnProperty("arrayItems")    ? transformArray(typ.arrayItems, val)
+            : typ.hasOwnProperty("props")         ? transformObject(getProps(typ), typ.additional, val)
+            : invalidValue(typ, val, key, parent);
+    }
+    // Numbers can be parsed by Date but shouldn't be.
+    if (typ === Date && typeof val !== "number") return transformDate(val);
+    return transformPrimitive(typ, val);
+}
+
+function cast<T>(val: any, typ: any): T {
+    return transform(val, typ, jsonToJSProps);
+}
+
+function uncast<T>(val: T, typ: any): any {
+    return transform(val, typ, jsToJSONProps);
+}
+
+function l(typ: any) {
+    return { literal: typ };
+}
+
+function a(typ: any) {
+    return { arrayItems: typ };
+}
+
+function u(...typs: any[]) {
+    return { unionMembers: typs };
+}
+
+function o(props: any[], additional: any) {
+    return { props, additional };
+}
+
+function m(additional: any) {
+    return { props: [], additional };
+}
+
+function r(name: string) {
+    return { ref: name };
+}
+
+const typeMap: any = {
+    "XML": o([
+        { json: "ThreatModel", js: "ThreatModel", typ: r("ThreatModel") },
+    ], false),
+    "ThreatModel": o([
+        { json: "DrawingSurfaceList", js: "DrawingSurfaceList", typ: r("DrawingSurfaceList") },
+        { json: "MetaInformation", js: "MetaInformation", typ: r("MetaInformation") },
+        { json: "Notes", js: "Notes", typ: "" },
+        { json: "ThreatGenerationEnabled", js: "ThreatGenerationEnabled", typ: true },
+        { json: "Validations", js: "Validations", typ: "" },
+        { json: "Version", js: "Version", typ: 3.14 },
+        { json: "Profile", js: "Profile", typ: r("Profile") },
+    ], false),
+    "DrawingSurfaceList": o([
+        { json: "DrawingSurfaceModel", js: "DrawingSurfaceModel", typ: r("DrawingSurfaceModel") },
+    ], false),
+    "DrawingSurfaceModel": o([
+        { json: "GenericTypeId", js: "GenericTypeId", typ: "" },
+        { json: "Guid", js: "Guid", typ: "" },
+        { json: "Properties", js: "Properties", typ: r("DrawingSurfaceModelProperties") },
+        { json: "TypeId", js: "TypeId", typ: "" },
+        { json: "Borders", js: "Borders", typ: r("Borders") },
+        { json: "Header", js: "Header", typ: "" },
+        { json: "Lines", js: "Lines", typ: r("Lines") },
+        { json: "Zoom", js: "Zoom", typ: 0 },
+    ], false),
+    "Borders": o([
+        { json: "KeyValueOfguidanyType", js: "KeyValueOfguidanyType", typ: a(r("BordersKeyValueOfguidanyType")) },
+    ], false),
+    "BordersKeyValueOfguidanyType": o([
+        { json: "Key", js: "Key", typ: "" },
+        { json: "Value", js: "Value", typ: r("PurpleValue") },
+    ], false),
+    "PurpleValue": o([
+        { json: "GenericTypeId", js: "GenericTypeId", typ: "" },
+        { json: "Guid", js: "Guid", typ: "" },
+        { json: "Properties", js: "Properties", typ: r("PurpleProperties") },
+        { json: "TypeId", js: "TypeId", typ: "" },
+        { json: "Height", js: "Height", typ: 0 },
+        { json: "Left", js: "Left", typ: 0 },
+        { json: "StrokeDashArray", js: "StrokeDashArray", typ: "" },
+        { json: "StrokeThickness", js: "StrokeThickness", typ: 0 },
+        { json: "Top", js: "Top", typ: 0 },
+        { json: "Width", js: "Width", typ: 0 },
+    ], false),
+    "PurpleProperties": o([
+        { json: "anyType", js: "anyType", typ: a(r("PurpleAnyType")) },
+    ], false),
+    "PurpleAnyType": o([
+        { json: "DisplayName", js: "DisplayName", typ: "" },
+        { json: "Name", js: "Name", typ: "" },
+        { json: "Value", js: "Value", typ: u(true, r("FluffyValue"), 0, "") },
+        { json: "SelectedIndex", js: "SelectedIndex", typ: u(undefined, 0) },
+    ], false),
+    "FluffyValue": o([
+        { json: "string", js: "string", typ: a("") },
+    ], false),
+    "Lines": o([
+        { json: "KeyValueOfguidanyType", js: "KeyValueOfguidanyType", typ: a(r("LinesKeyValueOfguidanyType")) },
+    ], false),
+    "LinesKeyValueOfguidanyType": o([
+        { json: "Key", js: "Key", typ: "" },
+        { json: "Value", js: "Value", typ: r("TentacledValue") },
+    ], false),
+    "TentacledValue": o([
+        { json: "GenericTypeId", js: "GenericTypeId", typ: "" },
+        { json: "Guid", js: "Guid", typ: "" },
+        { json: "Properties", js: "Properties", typ: r("FluffyProperties") },
+        { json: "TypeId", js: "TypeId", typ: "" },
+        { json: "HandleX", js: "HandleX", typ: 0 },
+        { json: "HandleY", js: "HandleY", typ: 0 },
+        { json: "PortSource", js: "PortSource", typ: "" },
+        { json: "PortTarget", js: "PortTarget", typ: "" },
+        { json: "SourceGuid", js: "SourceGuid", typ: "" },
+        { json: "SourceX", js: "SourceX", typ: 0 },
+        { json: "SourceY", js: "SourceY", typ: 0 },
+        { json: "TargetGuid", js: "TargetGuid", typ: "" },
+        { json: "TargetX", js: "TargetX", typ: 0 },
+        { json: "TargetY", js: "TargetY", typ: 0 },
+    ], false),
+    "FluffyProperties": o([
+        { json: "anyType", js: "anyType", typ: a(r("FluffyAnyType")) },
+    ], false),
+    "FluffyAnyType": o([
+        { json: "DisplayName", js: "DisplayName", typ: "" },
+        { json: "Name", js: "Name", typ: "" },
+        { json: "Value", js: "Value", typ: u(true, r("StickyValue"), r("ValueEnum"), 0) },
+        { json: "SelectedIndex", js: "SelectedIndex", typ: u(undefined, 0) },
+    ], false),
+    "StickyValue": o([
+        { json: "string", js: "string", typ: u(a(""), "") },
+    ], false),
+    "DrawingSurfaceModelProperties": o([
+        { json: "anyType", js: "anyType", typ: a(r("TentacledAnyType")) },
+    ], false),
+    "TentacledAnyType": o([
+        { json: "DisplayName", js: "DisplayName", typ: "" },
+        { json: "Name", js: "Name", typ: "" },
+        { json: "Value", js: "Value", typ: "" },
+    ], false),
+    "MetaInformation": o([
+        { json: "Assumptions", js: "Assumptions", typ: "" },
+        { json: "Contributors", js: "Contributors", typ: "" },
+        { json: "ExternalDependencies", js: "ExternalDependencies", typ: "" },
+        { json: "HighLevelSystemDescription", js: "HighLevelSystemDescription", typ: "" },
+        { json: "Owner", js: "Owner", typ: "" },
+        { json: "Reviewer", js: "Reviewer", typ: "" },
+        { json: "ThreatModelName", js: "ThreatModelName", typ: "" },
+    ], false),
+    "Profile": o([
+        { json: "PromptedKb", js: "PromptedKb", typ: "" },
+    ], false),
+    "ValueEnum": [
+        "",
+        "Generic Data\n                  Flow",
+        "HTTPS",
+    ],
+};

--- a/support/test-fixtures/xml-to-json-mtm.xml
+++ b/support/test-fixtures/xml-to-json-mtm.xml
@@ -1,0 +1,1914 @@
+<ThreatModel xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model"
+  xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <DrawingSurfaceList>
+    <DrawingSurfaceModel z:Id="i1" xmlns:z="http://schemas.microsoft.com/2003/10/Serialization/">
+      <GenericTypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+        DRAWINGSURFACE</GenericTypeId>
+      <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+        d8c8aab1-5108-49c5-92a1-b214ba353477</Guid>
+      <Properties xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts"
+        xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+        <a:anyType i:type="b:HeaderDisplayAttribute"
+          xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+          <b:DisplayName>Diagram</b:DisplayName>
+          <b:Name />
+          <b:Value i:nil="true" />
+        </a:anyType>
+        <a:anyType i:type="b:StringDisplayAttribute"
+          xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+          <b:DisplayName>Name</b:DisplayName>
+          <b:Name />
+          <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">Diagram 1</b:Value>
+        </a:anyType>
+      </Properties>
+      <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+        DRAWINGSURFACE</TypeId>
+      <Borders xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+        <a:KeyValueOfguidanyType>
+          <a:Key>41cb799f-434b-4b35-bd8e-8970bb985ec9</a:Key>
+          <a:Value z:Id="i2" i:type="StencilRectangle">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.EI</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              41cb799f-434b-4b35-bd8e-8970bb985ec9</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Generic External Interactor</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">Generic
+                  External Interactor</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:BooleanDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Out Of Scope</b:DisplayName>
+                <b:Name>71f3d9aa-b8ef-4e54-8126-607a1d903103</b:Name>
+                <b:Value i:type="c:boolean" xmlns:c="http://www.w3.org/2001/XMLSchema">false</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Reason For Out Of Scope</b:DisplayName>
+                <b:Name>752473b6-52d4-4776-9a24-202153f7d579</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Configurable Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Authenticates Itself</b:DisplayName>
+                <b:Name>authenticatesItself</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Applicable</a:string>
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>1</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Type</b:DisplayName>
+                <b:Name>type</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Code</a:string>
+                  <a:string>Human</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Microsoft</b:DisplayName>
+                <b:Name>MS</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              GE.EI</TypeId>
+            <Height xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              100</Height>
+            <Left xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">675</Left>
+            <StrokeDashArray i:nil="true"
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts" />
+            <StrokeThickness
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">1</StrokeThickness>
+            <Top xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">157</Top>
+            <Width xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              100</Width>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+        <a:KeyValueOfguidanyType>
+          <a:Key>7d402f21-b92a-4eeb-9b9d-362903405551</a:Key>
+          <a:Value z:Id="i3" i:type="StencilEllipse">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.P</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              7d402f21-b92a-4eeb-9b9d-362903405551</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>OS Process</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">OS Process</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:BooleanDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Out Of Scope</b:DisplayName>
+                <b:Name>71f3d9aa-b8ef-4e54-8126-607a1d903103</b:Name>
+                <b:Value i:type="c:boolean" xmlns:c="http://www.w3.org/2001/XMLSchema">false</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Reason For Out Of Scope</b:DisplayName>
+                <b:Name>752473b6-52d4-4776-9a24-202153f7d579</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Configurable Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>As Generic Process</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Code Type</b:DisplayName>
+                <b:Name>codeType</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Managed</a:string>
+                  <a:string>Unmanaged</a:string>
+                </b:Value>
+                <b:SelectedIndex>1</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Running As</b:DisplayName>
+                <b:Name>runningAs</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Kernel</a:string>
+                  <a:string>System</a:string>
+                  <a:string>Network Service</a:string>
+                  <a:string>Local Service</a:string>
+                  <a:string>Administrator</a:string>
+                  <a:string>Standard User With Elevation</a:string>
+                  <a:string>Standard User Without Elevation</a:string>
+                  <a:string>Windows Store App</a:string>
+                </b:Value>
+                <b:SelectedIndex>5</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Isolation Level</b:DisplayName>
+                <b:Name>Isolation</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>AppContainer</a:string>
+                  <a:string>Low Integrity Level</a:string>
+                  <a:string>Microsoft Office Isolated Conversion Environment (MOICE)</a:string>
+                  <a:string>Sandbox</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Accepts Input From</b:DisplayName>
+                <b:Name>acceptsInputFrom</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Any Remote User or Entity</a:string>
+                  <a:string>Kernel, System, or Local Admin</a:string>
+                  <a:string>Local or Network Service</a:string>
+                  <a:string>Local Standard User With Elevation</a:string>
+                  <a:string>Local Standard User Without Elevation</a:string>
+                  <a:string>Windows Store Apps or App Container Processes</a:string>
+                  <a:string>Nothing</a:string>
+                  <a:string>Other</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Implements or Uses an Authentication Mechanism</b:DisplayName>
+                <b:Name>implementsAuthenticationScheme</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Implements or Uses an Authorization Mechanism</b:DisplayName>
+                <b:Name>implementsCustomAuthorizationMechanism</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Implements or Uses a Communication Protocol</b:DisplayName>
+                <b:Name>implementsCommunicationProtocol</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Sanitizes Input</b:DisplayName>
+                <b:Name>hasInputSanitizers</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Yes</a:string>
+                  <a:string>No</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Sanitizes Output</b:DisplayName>
+                <b:Name>hasOutputSanitizers</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Yes</a:string>
+                  <a:string>No</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              SE.P.TMCore.OSProcess</TypeId>
+            <Height xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              100</Height>
+            <Left xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">263</Left>
+            <StrokeDashArray i:nil="true"
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts" />
+            <StrokeThickness
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">1</StrokeThickness>
+            <Top xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">119</Top>
+            <Width xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              100</Width>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+        <a:KeyValueOfguidanyType>
+          <a:Key>627d2636-7f62-481c-a46f-7af41e24c937</a:Key>
+          <a:Value z:Id="i4" i:type="StencilEllipse">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.P</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              627d2636-7f62-481c-a46f-7af41e24c937</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>OS Process</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">OS Process</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:BooleanDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Out Of Scope</b:DisplayName>
+                <b:Name>71f3d9aa-b8ef-4e54-8126-607a1d903103</b:Name>
+                <b:Value i:type="c:boolean" xmlns:c="http://www.w3.org/2001/XMLSchema">false</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Reason For Out Of Scope</b:DisplayName>
+                <b:Name>752473b6-52d4-4776-9a24-202153f7d579</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Configurable Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>As Generic Process</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Code Type</b:DisplayName>
+                <b:Name>codeType</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Managed</a:string>
+                  <a:string>Unmanaged</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Running As</b:DisplayName>
+                <b:Name>runningAs</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Kernel</a:string>
+                  <a:string>System</a:string>
+                  <a:string>Network Service</a:string>
+                  <a:string>Local Service</a:string>
+                  <a:string>Administrator</a:string>
+                  <a:string>Standard User With Elevation</a:string>
+                  <a:string>Standard User Without Elevation</a:string>
+                  <a:string>Windows Store App</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Isolation Level</b:DisplayName>
+                <b:Name>Isolation</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>AppContainer</a:string>
+                  <a:string>Low Integrity Level</a:string>
+                  <a:string>Microsoft Office Isolated Conversion Environment (MOICE)</a:string>
+                  <a:string>Sandbox</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Accepts Input From</b:DisplayName>
+                <b:Name>acceptsInputFrom</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Any Remote User or Entity</a:string>
+                  <a:string>Kernel, System, or Local Admin</a:string>
+                  <a:string>Local or Network Service</a:string>
+                  <a:string>Local Standard User With Elevation</a:string>
+                  <a:string>Local Standard User Without Elevation</a:string>
+                  <a:string>Windows Store Apps or App Container Processes</a:string>
+                  <a:string>Nothing</a:string>
+                  <a:string>Other</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Implements or Uses an Authentication Mechanism</b:DisplayName>
+                <b:Name>implementsAuthenticationScheme</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Implements or Uses an Authorization Mechanism</b:DisplayName>
+                <b:Name>implementsCustomAuthorizationMechanism</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Implements or Uses a Communication Protocol</b:DisplayName>
+                <b:Name>implementsCommunicationProtocol</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Sanitizes Input</b:DisplayName>
+                <b:Name>hasInputSanitizers</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Yes</a:string>
+                  <a:string>No</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Sanitizes Output</b:DisplayName>
+                <b:Name>hasOutputSanitizers</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Yes</a:string>
+                  <a:string>No</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              SE.P.TMCore.OSProcess</TypeId>
+            <Height xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              100</Height>
+            <Left xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">454</Left>
+            <StrokeDashArray i:nil="true"
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts" />
+            <StrokeThickness
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">1</StrokeThickness>
+            <Top xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">124</Top>
+            <Width xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              100</Width>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+        <a:KeyValueOfguidanyType>
+          <a:Key>f5e8c8a7-e181-4fb3-a183-3428f69f8bab</a:Key>
+          <a:Value z:Id="i5" i:type="StencilParallelLines">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.DS</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              f5e8c8a7-e181-4fb3-a183-3428f69f8bab</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Generic Data Store</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">Generic Data
+                  Store</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:BooleanDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Out Of Scope</b:DisplayName>
+                <b:Name>71f3d9aa-b8ef-4e54-8126-607a1d903103</b:Name>
+                <b:Value i:type="c:boolean" xmlns:c="http://www.w3.org/2001/XMLSchema">false</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Reason For Out Of Scope</b:DisplayName>
+                <b:Name>752473b6-52d4-4776-9a24-202153f7d579</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Configurable Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Stores Credentials</b:DisplayName>
+                <b:Name>storesCredentials</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Stores Log Data</b:DisplayName>
+                <b:Name>storesLogData</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Encrypted</b:DisplayName>
+                <b:Name>Encrypted</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Signed</b:DisplayName>
+                <b:Name>Signed</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Write Access</b:DisplayName>
+                <b:Name>AccessType</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Removable Storage</b:DisplayName>
+                <b:Name>RemoveableStorage</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Backup</b:DisplayName>
+                <b:Name>Backup</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Shared</b:DisplayName>
+                <b:Name>shared</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Store Type</b:DisplayName>
+                <b:Name>storeType</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>SQL Relational Database</a:string>
+                  <a:string>Non Relational Database</a:string>
+                  <a:string>File System</a:string>
+                  <a:string>Registry</a:string>
+                  <a:string>Configuration</a:string>
+                  <a:string>Cache</a:string>
+                  <a:string>HTML5 Storage</a:string>
+                  <a:string>Cookie</a:string>
+                  <a:string>Device</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              GE.DS</TypeId>
+            <Height xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              100</Height>
+            <Left xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">11</Left>
+            <StrokeDashArray i:nil="true"
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts" />
+            <StrokeThickness
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">1</StrokeThickness>
+            <Top xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">131</Top>
+            <Width xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              100</Width>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+        <a:KeyValueOfguidanyType>
+          <a:Key>2630a387-0a98-4028-9cdd-6f514b6a4b5d</a:Key>
+          <a:Value z:Id="i6" i:type="BorderBoundary">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.TB.B</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              2630a387-0a98-4028-9cdd-6f514b6a4b5d</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Generic Trust Border Boundary</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">Generic Trust
+                  Border Boundary</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Dataflow Order</b:DisplayName>
+                <b:Name>15ccd509-98eb-49ad-b9c2-b4a2926d1780</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">0</b:Value>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              GE.TB.B</TypeId>
+            <Height xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              313</Height>
+            <Left xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">182</Left>
+            <StrokeDashArray i:nil="true"
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts" />
+            <StrokeThickness
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">1</StrokeThickness>
+            <Top xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">25</Top>
+            <Width xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              429</Width>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+      </Borders>
+      <Header>Diagram 1</Header>
+      <Lines xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+        <a:KeyValueOfguidanyType>
+          <a:Key>f367ac70-74ff-4ba1-abc4-0ac96e350448</a:Key>
+          <a:Value z:Id="i7" i:type="Connector">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.DF</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              f367ac70-74ff-4ba1-abc4-0ac96e350448</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Generic Data Flow</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">Generic Data
+                  Flow</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Dataflow Order</b:DisplayName>
+                <b:Name>15ccd509-98eb-49ad-b9c2-b4a2926d1780</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">0</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:BooleanDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Out Of Scope</b:DisplayName>
+                <b:Name>71f3d9aa-b8ef-4e54-8126-607a1d903103</b:Name>
+                <b:Value i:type="c:boolean" xmlns:c="http://www.w3.org/2001/XMLSchema">false</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Reason For Out Of Scope</b:DisplayName>
+                <b:Name>752473b6-52d4-4776-9a24-202153f7d579</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Configurable Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Physical Network</b:DisplayName>
+                <b:Name>channel</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Wire</a:string>
+                  <a:string>Wi-Fi</a:string>
+                  <a:string>Bluetooth</a:string>
+                  <a:string>2G-4G</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Source Authenticated</b:DisplayName>
+                <b:Name>authenticatesSource</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>1</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Destination Authenticated</b:DisplayName>
+                <b:Name>authenticatesDestination</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Confidentiality</b:DisplayName>
+                <b:Name>providesConfidentiality</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Integrity</b:DisplayName>
+                <b:Name>providesIntegrity</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Transmits XML</b:DisplayName>
+                <b:Name>XMLenc</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Contains Cookies</b:DisplayName>
+                <b:Name>Cookies</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                  <a:string>No</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>SOAP Payload</b:DisplayName>
+                <b:Name>SOAP</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>REST Payload</b:DisplayName>
+                <b:Name>REST</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>RSS Payload</b:DisplayName>
+                <b:Name>RSS</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>JSON Payload</b:DisplayName>
+                <b:Name>JSON</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Forgery Protection</b:DisplayName>
+                <b:Name>54851a3b-65da-4902-b4e0-94ef015be735</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>ValidateAntiForgeryTokenAttribute</a:string>
+                  <a:string>ViewStateUserKey</a:string>
+                  <a:string>Nonce</a:string>
+                  <a:string>Other dynamic canary</a:string>
+                  <a:string>Static header not available to the browser</a:string>
+                  <a:string>Other</a:string>
+                  <a:string>None</a:string>
+                  <a:string>Not applicable because the request does not change data</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              GE.DF</TypeId>
+            <HandleX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              180</HandleX>
+            <HandleY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              128</HandleY>
+            <PortSource
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">East</PortSource>
+            <PortTarget
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">West</PortTarget>
+            <SourceGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              f5e8c8a7-e181-4fb3-a183-3428f69f8bab</SourceGuid>
+            <SourceX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              106</SourceX>
+            <SourceY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              181</SourceY>
+            <TargetGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              7d402f21-b92a-4eeb-9b9d-362903405551</TargetGuid>
+            <TargetX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              268</TargetX>
+            <TargetY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              169</TargetY>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+        <a:KeyValueOfguidanyType>
+          <a:Key>89ae2a26-c3f6-417a-a217-eef7ce936719</a:Key>
+          <a:Value z:Id="i8" i:type="Connector">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.DF</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              89ae2a26-c3f6-417a-a217-eef7ce936719</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Generic Data Flow</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">Generic Data
+                  Flow</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Dataflow Order</b:DisplayName>
+                <b:Name>15ccd509-98eb-49ad-b9c2-b4a2926d1780</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">0</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:BooleanDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Out Of Scope</b:DisplayName>
+                <b:Name>71f3d9aa-b8ef-4e54-8126-607a1d903103</b:Name>
+                <b:Value i:type="c:boolean" xmlns:c="http://www.w3.org/2001/XMLSchema">false</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Reason For Out Of Scope</b:DisplayName>
+                <b:Name>752473b6-52d4-4776-9a24-202153f7d579</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Configurable Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Physical Network</b:DisplayName>
+                <b:Name>channel</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Wire</a:string>
+                  <a:string>Wi-Fi</a:string>
+                  <a:string>Bluetooth</a:string>
+                  <a:string>2G-4G</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Source Authenticated</b:DisplayName>
+                <b:Name>authenticatesSource</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>1</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Destination Authenticated</b:DisplayName>
+                <b:Name>authenticatesDestination</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Confidentiality</b:DisplayName>
+                <b:Name>providesConfidentiality</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Integrity</b:DisplayName>
+                <b:Name>providesIntegrity</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Transmits XML</b:DisplayName>
+                <b:Name>XMLenc</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Contains Cookies</b:DisplayName>
+                <b:Name>Cookies</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                  <a:string>No</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>SOAP Payload</b:DisplayName>
+                <b:Name>SOAP</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>REST Payload</b:DisplayName>
+                <b:Name>REST</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>RSS Payload</b:DisplayName>
+                <b:Name>RSS</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>JSON Payload</b:DisplayName>
+                <b:Name>JSON</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Forgery Protection</b:DisplayName>
+                <b:Name>54851a3b-65da-4902-b4e0-94ef015be735</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>ValidateAntiForgeryTokenAttribute</a:string>
+                  <a:string>ViewStateUserKey</a:string>
+                  <a:string>Nonce</a:string>
+                  <a:string>Other dynamic canary</a:string>
+                  <a:string>Static header not available to the browser</a:string>
+                  <a:string>Other</a:string>
+                  <a:string>None</a:string>
+                  <a:string>Not applicable because the request does not change data</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              GE.DF</TypeId>
+            <HandleX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              185</HandleX>
+            <HandleY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              219</HandleY>
+            <PortSource
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">West</PortSource>
+            <PortTarget
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">East</PortTarget>
+            <SourceGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              7d402f21-b92a-4eeb-9b9d-362903405551</SourceGuid>
+            <SourceX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              268</SourceX>
+            <SourceY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              169</SourceY>
+            <TargetGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              f5e8c8a7-e181-4fb3-a183-3428f69f8bab</TargetGuid>
+            <TargetX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              106</TargetX>
+            <TargetY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              181</TargetY>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+        <a:KeyValueOfguidanyType>
+          <a:Key>97499ed7-bcbd-45c4-867b-ffc85da6f2b2</a:Key>
+          <a:Value z:Id="i9" i:type="Connector">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.DF</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              97499ed7-bcbd-45c4-867b-ffc85da6f2b2</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Generic Data Flow</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">Generic Data
+                  Flow</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Dataflow Order</b:DisplayName>
+                <b:Name>15ccd509-98eb-49ad-b9c2-b4a2926d1780</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">0</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:BooleanDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Out Of Scope</b:DisplayName>
+                <b:Name>71f3d9aa-b8ef-4e54-8126-607a1d903103</b:Name>
+                <b:Value i:type="c:boolean" xmlns:c="http://www.w3.org/2001/XMLSchema">false</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Reason For Out Of Scope</b:DisplayName>
+                <b:Name>752473b6-52d4-4776-9a24-202153f7d579</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Configurable Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Physical Network</b:DisplayName>
+                <b:Name>channel</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Wire</a:string>
+                  <a:string>Wi-Fi</a:string>
+                  <a:string>Bluetooth</a:string>
+                  <a:string>2G-4G</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Source Authenticated</b:DisplayName>
+                <b:Name>authenticatesSource</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>1</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Destination Authenticated</b:DisplayName>
+                <b:Name>authenticatesDestination</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Confidentiality</b:DisplayName>
+                <b:Name>providesConfidentiality</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Integrity</b:DisplayName>
+                <b:Name>providesIntegrity</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Transmits XML</b:DisplayName>
+                <b:Name>XMLenc</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Contains Cookies</b:DisplayName>
+                <b:Name>Cookies</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                  <a:string>No</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>SOAP Payload</b:DisplayName>
+                <b:Name>SOAP</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>REST Payload</b:DisplayName>
+                <b:Name>REST</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>RSS Payload</b:DisplayName>
+                <b:Name>RSS</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>JSON Payload</b:DisplayName>
+                <b:Name>JSON</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Forgery Protection</b:DisplayName>
+                <b:Name>54851a3b-65da-4902-b4e0-94ef015be735</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>ValidateAntiForgeryTokenAttribute</a:string>
+                  <a:string>ViewStateUserKey</a:string>
+                  <a:string>Nonce</a:string>
+                  <a:string>Other dynamic canary</a:string>
+                  <a:string>Static header not available to the browser</a:string>
+                  <a:string>Other</a:string>
+                  <a:string>None</a:string>
+                  <a:string>Not applicable because the request does not change data</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              GE.DF</TypeId>
+            <HandleX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              415</HandleX>
+            <HandleY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              124</HandleY>
+            <PortSource
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">West</PortSource>
+            <PortTarget
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">East</PortTarget>
+            <SourceGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              627d2636-7f62-481c-a46f-7af41e24c937</SourceGuid>
+            <SourceX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              459</SourceX>
+            <SourceY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              174</SourceY>
+            <TargetGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              7d402f21-b92a-4eeb-9b9d-362903405551</TargetGuid>
+            <TargetX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              358</TargetX>
+            <TargetY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              169</TargetY>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+        <a:KeyValueOfguidanyType>
+          <a:Key>060c42a9-68a9-4216-8b96-5443e65a4d56</a:Key>
+          <a:Value z:Id="i10" i:type="Connector">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.DF</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              060c42a9-68a9-4216-8b96-5443e65a4d56</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Generic Data Flow</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">Generic Data
+                  Flow</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Dataflow Order</b:DisplayName>
+                <b:Name>15ccd509-98eb-49ad-b9c2-b4a2926d1780</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">0</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:BooleanDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Out Of Scope</b:DisplayName>
+                <b:Name>71f3d9aa-b8ef-4e54-8126-607a1d903103</b:Name>
+                <b:Value i:type="c:boolean" xmlns:c="http://www.w3.org/2001/XMLSchema">false</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Reason For Out Of Scope</b:DisplayName>
+                <b:Name>752473b6-52d4-4776-9a24-202153f7d579</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Configurable Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Physical Network</b:DisplayName>
+                <b:Name>channel</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Wire</a:string>
+                  <a:string>Wi-Fi</a:string>
+                  <a:string>Bluetooth</a:string>
+                  <a:string>2G-4G</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Source Authenticated</b:DisplayName>
+                <b:Name>authenticatesSource</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>2</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Destination Authenticated</b:DisplayName>
+                <b:Name>authenticatesDestination</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Confidentiality</b:DisplayName>
+                <b:Name>providesConfidentiality</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>1</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Integrity</b:DisplayName>
+                <b:Name>providesIntegrity</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Transmits XML</b:DisplayName>
+                <b:Name>XMLenc</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>1</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Contains Cookies</b:DisplayName>
+                <b:Name>Cookies</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                  <a:string>No</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>SOAP Payload</b:DisplayName>
+                <b:Name>SOAP</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>REST Payload</b:DisplayName>
+                <b:Name>REST</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>RSS Payload</b:DisplayName>
+                <b:Name>RSS</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>JSON Payload</b:DisplayName>
+                <b:Name>JSON</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Forgery Protection</b:DisplayName>
+                <b:Name>54851a3b-65da-4902-b4e0-94ef015be735</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>ValidateAntiForgeryTokenAttribute</a:string>
+                  <a:string>ViewStateUserKey</a:string>
+                  <a:string>Nonce</a:string>
+                  <a:string>Other dynamic canary</a:string>
+                  <a:string>Static header not available to the browser</a:string>
+                  <a:string>Other</a:string>
+                  <a:string>None</a:string>
+                  <a:string>Not applicable because the request does not change data</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              GE.DF</TypeId>
+            <HandleX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              410</HandleX>
+            <HandleY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              207</HandleY>
+            <PortSource
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">East</PortSource>
+            <PortTarget
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">West</PortTarget>
+            <SourceGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              7d402f21-b92a-4eeb-9b9d-362903405551</SourceGuid>
+            <SourceX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              358</SourceX>
+            <SourceY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              169</SourceY>
+            <TargetGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              627d2636-7f62-481c-a46f-7af41e24c937</TargetGuid>
+            <TargetX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              459</TargetX>
+            <TargetY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              174</TargetY>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+        <a:KeyValueOfguidanyType>
+          <a:Key>59332388-df08-4b98-b15a-14112782984b</a:Key>
+          <a:Value z:Id="i11" i:type="Connector">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.DF</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              59332388-df08-4b98-b15a-14112782984b</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>HTTPS</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">HTTPS</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Dataflow Order</b:DisplayName>
+                <b:Name>15ccd509-98eb-49ad-b9c2-b4a2926d1780</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">0</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:BooleanDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Out Of Scope</b:DisplayName>
+                <b:Name>71f3d9aa-b8ef-4e54-8126-607a1d903103</b:Name>
+                <b:Value i:type="c:boolean" xmlns:c="http://www.w3.org/2001/XMLSchema">false</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Reason For Out Of Scope</b:DisplayName>
+                <b:Name>752473b6-52d4-4776-9a24-202153f7d579</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Predefined Static Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StaticListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Destination Authenticated</b:DisplayName>
+                <b:Name>authenticatesDestination</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:StaticListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Confidentiality</b:DisplayName>
+                <b:Name>providesConfidentiality</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:StaticListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Integrity</b:DisplayName>
+                <b:Name>providesIntegrity</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Configurable Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>As Generic Data Flow</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Physical Network</b:DisplayName>
+                <b:Name>channel</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Wire</a:string>
+                  <a:string>Wi-Fi</a:string>
+                  <a:string>Bluetooth</a:string>
+                  <a:string>2G-4G</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Source Authenticated</b:DisplayName>
+                <b:Name>authenticatesSource</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>1</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Transmits XML</b:DisplayName>
+                <b:Name>XMLenc</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Contains Cookies</b:DisplayName>
+                <b:Name>Cookies</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                  <a:string>No</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>SOAP Payload</b:DisplayName>
+                <b:Name>SOAP</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>REST Payload</b:DisplayName>
+                <b:Name>REST</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>RSS Payload</b:DisplayName>
+                <b:Name>RSS</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>JSON Payload</b:DisplayName>
+                <b:Name>JSON</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Forgery Protection</b:DisplayName>
+                <b:Name>54851a3b-65da-4902-b4e0-94ef015be735</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>ValidateAntiForgeryTokenAttribute</a:string>
+                  <a:string>ViewStateUserKey</a:string>
+                  <a:string>Nonce</a:string>
+                  <a:string>Other dynamic canary</a:string>
+                  <a:string>Static header not available to the browser</a:string>
+                  <a:string>Other</a:string>
+                  <a:string>None</a:string>
+                  <a:string>Not applicable because the request does not change data</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              SE.DF.TMCore.HTTPS</TypeId>
+            <HandleX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              628</HandleX>
+            <HandleY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              149</HandleY>
+            <PortSource
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">West</PortSource>
+            <PortTarget
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              SouthEast</PortTarget>
+            <SourceGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              41cb799f-434b-4b35-bd8e-8970bb985ec9</SourceGuid>
+            <SourceX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              680</SourceX>
+            <SourceY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              207</SourceY>
+            <TargetGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              627d2636-7f62-481c-a46f-7af41e24c937</TargetGuid>
+            <TargetX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              535</TargetX>
+            <TargetY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              205</TargetY>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+        <a:KeyValueOfguidanyType>
+          <a:Key>08e0b8f7-07c4-47f0-a456-4090ceac2719</a:Key>
+          <a:Value z:Id="i12" i:type="Connector">
+            <GenericTypeId
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">GE.DF</GenericTypeId>
+            <Guid xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              08e0b8f7-07c4-47f0-a456-4090ceac2719</Guid>
+            <Properties
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>HTTPS</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Name</b:DisplayName>
+                <b:Name />
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">HTTPS</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Dataflow Order</b:DisplayName>
+                <b:Name>15ccd509-98eb-49ad-b9c2-b4a2926d1780</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema">0</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:BooleanDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Out Of Scope</b:DisplayName>
+                <b:Name>71f3d9aa-b8ef-4e54-8126-607a1d903103</b:Name>
+                <b:Value i:type="c:boolean" xmlns:c="http://www.w3.org/2001/XMLSchema">false</b:Value>
+              </a:anyType>
+              <a:anyType i:type="b:StringDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Reason For Out Of Scope</b:DisplayName>
+                <b:Name>752473b6-52d4-4776-9a24-202153f7d579</b:Name>
+                <b:Value i:type="c:string" xmlns:c="http://www.w3.org/2001/XMLSchema" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Predefined Static Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:StaticListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Destination Authenticated</b:DisplayName>
+                <b:Name>authenticatesDestination</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:StaticListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Confidentiality</b:DisplayName>
+                <b:Name>providesConfidentiality</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:StaticListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Provides Integrity</b:DisplayName>
+                <b:Name>providesIntegrity</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Configurable Attributes</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:HeaderDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>As Generic Data Flow</b:DisplayName>
+                <b:Name />
+                <b:Value i:nil="true" />
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Physical Network</b:DisplayName>
+                <b:Name>channel</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>Wire</a:string>
+                  <a:string>Wi-Fi</a:string>
+                  <a:string>Bluetooth</a:string>
+                  <a:string>2G-4G</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Source Authenticated</b:DisplayName>
+                <b:Name>authenticatesSource</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>1</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Transmits XML</b:DisplayName>
+                <b:Name>XMLenc</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Contains Cookies</b:DisplayName>
+                <b:Name>Cookies</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Yes</a:string>
+                  <a:string>No</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>SOAP Payload</b:DisplayName>
+                <b:Name>SOAP</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>REST Payload</b:DisplayName>
+                <b:Name>REST</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>RSS Payload</b:DisplayName>
+                <b:Name>RSS</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>JSON Payload</b:DisplayName>
+                <b:Name>JSON</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>No</a:string>
+                  <a:string>Yes</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+              <a:anyType i:type="b:ListDisplayAttribute"
+                xmlns:b="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase">
+                <b:DisplayName>Forgery Protection</b:DisplayName>
+                <b:Name>54851a3b-65da-4902-b4e0-94ef015be735</b:Name>
+                <b:Value i:type="a:ArrayOfstring">
+                  <a:string>Not Selected</a:string>
+                  <a:string>ValidateAntiForgeryTokenAttribute</a:string>
+                  <a:string>ViewStateUserKey</a:string>
+                  <a:string>Nonce</a:string>
+                  <a:string>Other dynamic canary</a:string>
+                  <a:string>Static header not available to the browser</a:string>
+                  <a:string>Other</a:string>
+                  <a:string>None</a:string>
+                  <a:string>Not applicable because the request does not change data</a:string>
+                </b:Value>
+                <b:SelectedIndex>0</b:SelectedIndex>
+              </a:anyType>
+            </Properties>
+            <TypeId xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              SE.DF.TMCore.HTTPS</TypeId>
+            <HandleX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              628</HandleX>
+            <HandleY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              245</HandleY>
+            <PortSource
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              SouthEast</PortSource>
+            <PortTarget
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">West</PortTarget>
+            <SourceGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              627d2636-7f62-481c-a46f-7af41e24c937</SourceGuid>
+            <SourceX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              535</SourceX>
+            <SourceY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              205</SourceY>
+            <TargetGuid
+              xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              41cb799f-434b-4b35-bd8e-8970bb985ec9</TargetGuid>
+            <TargetX xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              680</TargetX>
+            <TargetY xmlns="http://schemas.datacontract.org/2004/07/ThreatModeling.Model.Abstracts">
+              207</TargetY>
+          </a:Value>
+        </a:KeyValueOfguidanyType>
+      </Lines>
+      <Zoom>1</Zoom>
+    </DrawingSurfaceModel>
+  </DrawingSurfaceList>
+  <MetaInformation>
+    <Assumptions />
+    <Contributors />
+    <ExternalDependencies />
+    <HighLevelSystemDescription />
+    <Owner />
+    <Reviewer />
+    <ThreatModelName />
+  </MetaInformation>
+  <Notes />
+  <ThreatGenerationEnabled>true</ThreatGenerationEnabled>
+  <Validations xmlns:a="http://schemas.datacontract.org/2004/07/ThreatModeling.KnowledgeBase" />
+  <Version>4.3</Version>
+  <Profile>
+    <PromptedKb xmlns="" />
+  </Profile>
+</ThreatModel>

--- a/support/test-fixtures/xml-to-json.surveilr[json].ts
+++ b/support/test-fixtures/xml-to-json.surveilr[json].ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run --allow-env
+
+import { XMLParser } from "npm:fast-xml-parser";
+import {
+  InputData,
+  jsonInputForTargetLanguage,
+  quicktype,
+} from "npm:quicktype-core";
+
+async function quicktypeJSON(
+  targetLanguage: string,
+  typeName: string,
+  jsonString: string,
+) {
+  const jsonInput = jsonInputForTargetLanguage(targetLanguage);
+
+  // We could add multiple samples for the same desired
+  // type, or many sources for other types. Here we're
+  // just making one type from one piece of sample JSON.
+  await jsonInput.addSource({
+    name: typeName,
+    samples: [jsonString],
+  });
+
+  const inputData = new InputData();
+  inputData.addInput(jsonInput);
+
+  return await quicktype({
+    inputData,
+    lang: targetLanguage,
+  });
+}
+
+const xmlFile = Deno.readTextFileSync("./xml-to-json-mtm.xml");
+const xmlParser = new XMLParser({
+  ignoreDeclaration: true,
+  preserveOrder: false,
+  ignoreAttributes: true,
+  attributeNamePrefix: "@",
+  removeNSPrefix: true,
+});
+
+const xmlJSON = JSON.stringify(await xmlParser.parse(xmlFile), undefined, "  ");
+
+const { lines: xmlJsonParser } = await quicktypeJSON(
+  "typescript",
+  "XML",
+  xmlJSON,
+);
+
+console.log(xmlJSON);
+Deno.writeTextFileSync(
+  "./xml-to-json-mtm-types.ts",
+  xmlJsonParser.join("\n"),
+);


### PR DESCRIPTION
Added a capturable executable file named `xml-to-json.surveilr[json].ts` to convert XML to JSON and create a TypeScript type definition file.

**Note:** The conversion process for lengthy XML files is taking too much time and failing in Surveilr. As a workaround, I have shortened the sample MTM XML file.